### PR TITLE
[Issue] Background can be disabled for Credits screen

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -321,7 +321,7 @@ static void R_InitTextureMapping (void)
         ;
       xtoviewangle[x] = (i<<ANGLETOFINESHIFT)-ANG90;
       // [FG] linear horizontal sky scrolling
-      linearskyangle[x] = ((viewwidth/2-x)*((SCREENWIDTH<<6)/viewwidth))*(ANG90/(NONWIDEWIDTH<<6)) / fovdiff; // [Nugget]
+      linearskyangle[x] = (int) (((viewwidth/2-x)*((SCREENWIDTH<<6)/viewwidth))*(ANG90/(NONWIDEWIDTH<<6))) / fovdiff; // [Nugget]
     }
 
   // Take out the fencepost cases from viewangletox.


### PR DESCRIPTION
Take this as an issue, not a PR. I had no other reliable way to let you know about this since there's no Issues tab in the repo.

Simply put, the feature to disable drawing of the menu background does its job a bit too well, so much so that it even disables the background for the Credits screen, causing a HOM:
![cher0000](https://github.com/xemonix0/Cherry-Doom/assets/73968015/05288f2f-04c2-4922-9f28-d26e1247ac9e)

A feature to disable the menu background was one of the first I implemented, so I had already encountered this issue. We can't get away with disabling background drawing globally.